### PR TITLE
use explicit arrow chain ordering over resource name 'before' ordering

### DIFF
--- a/manifests/local.pp
+++ b/manifests/local.pp
@@ -15,16 +15,16 @@ define python::local($version = undef, $ensure  = present) {
       ensure_resource('python::version', $version)
       $require = Python::Version[$version]
     }
+
   }
 
-  file {
-    "${name}/.python-version":
-      ensure  => $ensure,
-      content => "${version}\n",
-      replace => true,
-      require => $require;
-    "${name}/.pyenv-version":
-      ensure => absent,
-      before => "${name}/.python-version",
+  file { "${name}/.pyenv-version":
+    ensure => absent
+  } -> file { "${name}/.python-version":
+    ensure  => $ensure,
+    content => "${version}\n",
+    replace => true,
+    require => $require
   }
+
 }


### PR DESCRIPTION
when trying to do :

``` puppet
    file { "${my}/moneyball":
        ensure => 'directory',
    } -> python::local { "${my}/moneyball":
        version => '2.7.3'
    }
```

I encountered this gnarly error:

``` bash
Error: Parameter before failed on File[/Users/norton/my/moneyball/.pyenv-version]: No title provided and "/Users/norton/my/moneyball/.python-version" is not a valid resource reference at /opt/boxen/repo/shared/python/manifests/local.pp:25
Wrapped exception:
No title provided and "/Users/norton/my/moneyball/.python-version" is not a valid resource reference
```

Using arrow chaining over name ordering seems to fix it. Thoughts?
