### PR TITLE
Only install plugins after cloning pyenv repo

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -14,9 +14,10 @@ define python::plugin ($ensure, $source) {
   include python
 
   repository { "${python::pyenv_root}/plugins/${name}":
-    ensure => $ensure,
-    force  => true,
-    source => $source,
-    user   => $python::user,
+    ensure  => $ensure,
+    force   => true,
+    source  => $source,
+    user    => $python::user,
+    require => Repository[$python::pyenv_root],
   }
 }


### PR DESCRIPTION
This PR fixes a possible bug when you use the module in a new installation.

The `python::plugin` directive could run before `python::version` which will cause the script to fail when it tries to clone the pyenv repository to a directory that already has the `plugin` dir in it.
