### PR TITLE
Use ensure_resource() from stdlib for the readline package in order to a...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,9 +14,7 @@ class python(
   if $::osfamily == 'Darwin' {
     include boxen::config
 
-    package { 'readline':
-      ensure => latest,
-    }
+    ensure_resource('package','readline')
 
     file { "${boxen::config::envdir}/pyenv.sh":
       ensure => absent,


### PR DESCRIPTION
Avoid a duplicate declaration when used with puppet-ruby.

```
> ./script/boxen
Error: Duplicate declaration: Package[readline] is already declared; cannot redeclare at /opt/boxen/repo/shared/python/manifests/init.pp:19 on node mymacbook
Error: Duplicate declaration: Package[readline] is already declared; cannot redeclare at /opt/boxen/repo/shared/python/manifests/init.pp:19 on node mymacbook
```