### PR TITLE
Explicitly install readline from homebrew.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,8 @@ class python(
     include boxen::config
 
     package { 'readline':
-      ensure => latest,
+      ensure   => latest,
+      provider => homebrew,
     }
 
     file { "${boxen::config::envdir}/pyenv.sh":

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -20,6 +20,7 @@ describe 'python' do
 
     should contain_package("readline").with({
       :ensure => 'latest',
+      :provider => 'homebrew',
     })
 
     should contain_repository('/test/boxen/pyenv').with({


### PR DESCRIPTION
Addresses the following error:

```
Error: Parameter ensure failed on Package[readline]: Provider must have features 'upgradeable' to set 'ensure' to 'latest' at /opt/boxen/repo/shared/python/manifests/init.pp:19
Wrapped exception:
Provider must have features 'upgradeable' to set 'ensure' to 'latest'
Wrapped exception:
Provider must have features 'upgradeable' to set 'ensure' to 'latest'
```
