### PR TITLE
Fix for build issues on OS X 10.9 and 10.10

### DIFF
--- a/lib/facter/xcrun_sdk_path.rb
+++ b/lib/facter/xcrun_sdk_path.rb
@@ -1,0 +1,10 @@
+Facter.add("xcrun_sdk_path") do
+  setcode do
+    os = Facter.value('osfamily')
+    case os
+    when "Darwin"
+      myname = Facter::Core::Execution.exec('/usr/bin/xcrun --show-sdk-path')
+    end
+    myname
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,11 +7,28 @@ class python::params {
 
       $pyenv_root = "${boxen::config::home}/pyenv"
       $user       = $::boxen_user
-    }
 
+      # Moved from versions.pp -> Provide sane defaults but Hiera can be used to override
+      # See versions.pp for docs on how to override this data
+      case $::macosx_productversion_major {
+        /(10.9|10.10)/: {
+          $os_env = {
+            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include -I${::xcrun_sdk_path}/usr/include",
+            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
+          }
+        }
+        default: {
+          $os_env = {
+            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include",
+            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
+          }
+        }
+      }
+    }
     default: {
       $pyenv_root = '/usr/local/share/pyenv'
       $user       = 'root'
+      $os_env     = {}
     }
   }
 

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -4,13 +4,21 @@
 #
 #   python::version { '2.7.3': }
 #
+# Hiera override for CFLAGS and LDFLAGS example:
+#
+#   python::version::os_env:
+#       CFLAGS: -I/opt/X11/include -I/usr/include
+#       LDFLAGS: -L/opt/X11/lib
 
 define python::version(
   $ensure  = 'installed',
   $env     = {},
   $version = $name,
+  $os_env  = $python::params::os_env,
 ) {
   require python
+
+  notify { "OS_ENV Settings: ${os_env}": }
 
   case $version {
     /jython/: { require java }
@@ -23,26 +31,8 @@ define python::version(
       include homebrew::config
       include boxen::config
 
-      # Fix for 10.9 and 10.10 build issues
-      case $::macosx_productversion_major {
-        /(10.9|10.10)/: {
-          $os_env = {
-            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include -I${::xcrun_sdk_path}/usr/include",
-            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
-          }
-        }
-        default: {
-          $os_env = {
-            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include",
-            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
-          }
-        }
-      }
-
     }
-    default: {
-      $os_env = {}
-    }
+    default: { }
   }
 
   $dest = "${python::pyenv_root}/versions/${version}"

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -4,21 +4,20 @@
 #
 #   python::version { '2.7.3': }
 #
-# Hiera override for CFLAGS and LDFLAGS example:
+# NOTE: OS_ENV settings are sane for OS X but can easily be changed for your setup
+# See the Hiera example below:
 #
 #   python::version::os_env:
-#       CFLAGS: -I/opt/X11/include -I/usr/include
-#       LDFLAGS: -L/opt/X11/lib
+#       CFLAGS: "-I/opt/X11/include -I/usr/include"
+#       LDFLAGS: "-L/opt/X11/lib"
 
 define python::version(
   $ensure  = 'installed',
   $env     = {},
   $version = $name,
-  $os_env  = $python::params::os_env,
+  $os_env  = hiera_hash('python::version::os_env', $python::params::os_env),
 ) {
   require python
-
-  notify { "OS_ENV Settings: ${os_env}": }
 
   case $version {
     /jython/: { require java }

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -23,12 +23,23 @@ define python::version(
       include homebrew::config
       include boxen::config
 
-      $os_env = {
-        'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include",
-        'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
+      # Fix for 10.9 and 10.10 build issues
+      case $::macosx_productversion_major {
+        /(10.9|10.10)/: {
+          $os_env = {
+            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include -I${::xcrun_sdk_path}/usr/include",
+            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
+          }
+        }
+        default: {
+          $os_env = {
+            'CFLAGS'  => "-I${homebrew::config::installdir}/include -I/opt/X11/include",
+            'LDFLAGS' => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
+          }
+        }
       }
-    }
 
+    }
     default: {
       $os_env = {}
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 require "rspec-puppet"
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'hiera-puppet-helper/rspec'
+require 'hiera'
+require 'puppet/indirector/hiera'
 
 fixture_path = File.expand_path File.join(__FILE__, "..", "fixtures")
 


### PR DESCRIPTION
This fixes build issues for Python 2.7.X on OS X 10.9 and 10.10 (tested on 10.10 but should work on 10.9 also).
