### PR TITLE
Update pyenv to version v20151103

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,6 @@ python::version::alias:
 python::prefix: '/opt'
 python::user: "%{::id}"
 
-python::pyenv::ensure: v20150913
+python::pyenv::ensure: v20151103
 python::pyenv::prefix: "%{hiera('python::prefix')}/pyenv"
 python::pyenv::user: "%{hiera('python::user')}"


### PR DESCRIPTION
Fixes issue where ssl extension wouldn’t compile

Should resolve #18