### PR TITLE
allow multiple versions to be set as global

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -10,9 +10,15 @@ class python::global(
 ) {
   require python
 
-  if $version != 'system' {
-    ensure_resource('python::version', $version)
-    $require = Python::Version[$version]
+  if is_array($version) {
+    $version_list = $version
+  } else {
+    $version_list = split($version, '[, ]+')
+  }
+  $version_list_without_system = delete($version_list, 'system')
+  if count($version_list_without_system) > 0 {
+    ensure_resource('python::version', $version_list_without_system)
+    $require = Python::Version[$version_list_without_system]
   } else {
     $require = undef
   }
@@ -21,7 +27,7 @@ class python::global(
     ensure  => present,
     owner   => $python::user,
     mode    => '0644',
-    content => "${version}\n",
+    content => join($version_list, "\n"),
     require => $require,
   }
 }


### PR DESCRIPTION
This should fix #21, by allowing the user to pass in a comma or space separated list, or an array.

I've tested this on my slightly customized version of [puppet-python](https://github.com/halyard/puppet-python) and it appears to work, but it's probably worth a test run or two with the stock module to confirm.
