### PR TITLE
Enable framework support for Darwin (macOS)

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -3,7 +3,7 @@ python::version::env:
   Darwin:
     CFLAGS: "-I%{::homebrew::config::installdir}/include -I/opt/X11/include -march=core2 -O3"
     LDFLAGS: "-L%{::homebrew::config::installdir}/lib -L/opt/X11/lib"
-    PYTHON_CONFIGURE_OPTS: "--with-readline-dir=%{::homebrew::config::installdir}/opt/readline"
+    PYTHON_CONFIGURE_OPTS: "--with-readline-dir=%{::homebrew::config::installdir}/opt/readline --enable-framework"
 
 python::prefix: "%{::boxen::config::home}"
 python::user: "%{::boxen_user}"


### PR DESCRIPTION
Adding the  `--enable-framework` option lets `pyenv` builds work with PyInstaller (and presumably additional other libraries).

See: https://github.com/yyuu/pyenv/wiki#how-to-build-cpython-with-framework-support-on-os-x

https://github.com/yyuu/pyenv/issues/443 explains the issue and the need for the flag. I am not aware of any downsides to enabling this option.
